### PR TITLE
Support reading enum resources

### DIFF
--- a/ihcsdk/ihcclient.py
+++ b/ihcsdk/ihcclient.py
@@ -187,6 +187,12 @@ class IHCSoapClient:
             IHCSoapClient.ihcns)
         if floatresult is not None:
             return float(floatresult.text)
+        enumNameResut = xdoc.find(
+            ('./SOAP-ENV:Body/ns1:getRuntimeValue2/'
+             'ns1:value/ns2:enumName'),
+            IHCSoapClient.ihcns)
+        if enumNameResut is not None:
+            return enumNameResut.text
         return False
 
     def enable_runtime_notification(self, resourceid: int):
@@ -243,6 +249,12 @@ class IHCSoapClient:
                                IHCSoapClient.ihcns)
             if fvalue is not None:
                 changes[int(ihcid.text)] = float(fvalue.text)
+                continue
+            
+            enumName = item.find('./ns1:value/ns2:enumName',
+                               IHCSoapClient.ihcns)
+            if enumName is not None:
+                changes[int(ihcid.text)] = enumName.text
         return changes
 
     def get_user_log(self, language='da'):


### PR DESCRIPTION
Add support for reading the value of resources which are of type enum. 
Currently it is not possible to read these and they just show up with empty value. 
E.g. on the Alarm module there is an enum that specifies what caused the alarm to trigger, but if one adds that to e.g. Home Assistant it always shows empty. This is fixed with this PR.

Note: I have looked into being able to set enum values at runtime, but it will require more functionality to be added as setting an enum value requires 3 values: defintionTypeID, enumValueID and enumValue. These values can all be read from the project files. But is not that user friendly so some way of reading these from the project files should be added. However, in my rather large IHC project there was not a single enum value that could be set. They all had accessibility="read", so I don't think it is worth the effort to add this ability.