### PR TITLE
Fix for potential SSLError DH_KEY_TOO_SMALL

### DIFF
--- a/ihcsdk/ihccontroller.py
+++ b/ihcsdk/ihccontroller.py
@@ -6,6 +6,7 @@ Notify thread to handle change notifications
 from datetime import datetime, timedelta
 import requests
 import socket
+import sys
 import threading
 import time
 from ihcsdk.ihcclient import IHCSoapClient, IHCSTATE_READY
@@ -47,6 +48,7 @@ class IHCController:
                 return False
             return True
         except requests.exceptions.RequestException as exp:
+            print("is_ihc_controller: %s" % exp, file=sys.stderr)
             return False
 
     def authenticate(self) -> bool:

--- a/ihcsdk/ihcsslconnection.py
+++ b/ihcsdk/ihcsslconnection.py
@@ -42,7 +42,9 @@ class CertAdapter(requests.adapters.HTTPAdapter):
 
     def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
         """Create a custom poolmanager"""
-        CIPHERS = ('ALL:@SECLEVEL=1')
+        # CIPHERS = ('ALL:@SECLEVEL=1')
+        # CIPHERS = ('HIGH:!DH:!aNULL')
+        CIPHERS = ('DEFAULT:!DH')
         context = create_urllib3_context(ciphers=CIPHERS)
         pool_kwargs['ssl_context'] = context
         pool_kwargs["assert_fingerprint"] = self.fingerprint

--- a/ihcsdk/ihcsslconnection.py
+++ b/ihcsdk/ihcsslconnection.py
@@ -7,6 +7,7 @@ from cryptography.x509 import load_pem_x509_certificate
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.ssl_ import create_urllib3_context
 
 from ihcsdk.ihcconnection import IHCConnection
 
@@ -41,6 +42,9 @@ class CertAdapter(requests.adapters.HTTPAdapter):
 
     def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
         """Create a custom poolmanager"""
+        CIPHERS = ('ALL:@SECLEVEL=1')
+        context = create_urllib3_context(ciphers=CIPHERS)
+        pool_kwargs['ssl_context'] = context
         pool_kwargs["assert_fingerprint"] = self.fingerprint
         return super(CertAdapter, self).init_poolmanager(
             connections, maxsize, block, **pool_kwargs


### PR DESCRIPTION
* RequestException in `IHCController.is_ihc_controller():`
  HTTPSConnectionPool(host='usb', port=443): Max retries exceeded with url: /wsdl/controller.wsdl
  (Caused by SSLError(SSLError(1, '[SSL: DH_KEY_TOO_SMALL] dh key too small (_ssl.c:1056)')))
* Fixed by lowering security level in `IHCSSLConnection`